### PR TITLE
supports nim 0.19 and latest devel

### DIFF
--- a/q.nim
+++ b/q.nim
@@ -21,7 +21,7 @@ let
   attribute = r"[a-zA-Z][a-zA-Z0-9_\-]*"
   classes = r"{\.[a-zA-Z0-9_][a-zA-Z0-9_\-]*}"
   attributes = r"{\[" & attribute & r"\s*([\*\^\$\~]?\=\s*[\'""]?(\s*\ident\s*)+[\'""]?)?\]}"
-  pselectors = peg(r"\s*{\ident}?({'#'\ident})? (" & classes & ")* "& attributes & "*")
+  pselectors = peg(r"\s*{\ident}?({'#'\ident})? (" & classes & ")* " & attributes & "*")
   pattributes = peg(r"{\[{" & attribute & r"}\s*({[\*\^\$\~]?}\=\s*[\'""]?{(\s*\ident\s*)+}[\'""]?)?\]}")
 
 type
@@ -174,7 +174,7 @@ proc parseSelector(token: string): Selector =
   # Type selector
   elif token =~ pselectors:
     for i in 0..matches.len-1:
-      if matches[i].isNil:
+      if matches[i].len == 0:
         continue
 
       let ch = matches[i][0]


### PR DESCRIPTION
Fixes a warning (indentation) and an error (strings are now `nil`-hostile) to make the `nim@0.19` (and latest `devel`) compiler happy.

Heads up: I noticed in your `q.nimble` file you support `nim@0.10` and up.  Although this change is compatible with `nim@0.18` and up, I really don't know if it is compatible going all the way back to `0.10`.

Thank you kindly for this library.  It works well for my light html parsing needs... also, I'm shocked at how small the codebase is.  Great job.
